### PR TITLE
Update repo files to do key download via https

### DIFF
--- a/epel/ICINGA-release.repo
+++ b/epel/ICINGA-release.repo
@@ -3,4 +3,4 @@ name=ICINGA (stable release for epel)
 baseurl=http://packages.icinga.com/epel/$releasever/release/
 enabled=1
 gpgcheck=1
-gpgkey=http://packages.icinga.com/icinga.key
+gpgkey=https://packages.icinga.com/icinga.key

--- a/epel/ICINGA-snapshot.repo
+++ b/epel/ICINGA-snapshot.repo
@@ -3,5 +3,5 @@ name=ICINGA (snapshot builds for epel)
 baseurl=http://packages.icinga.com/epel/$releasever/snapshot/
 enabled=1
 gpgcheck=1
-gpgkey=http://packages.icinga.com/icinga.key
+gpgkey=https://packages.icinga.com/icinga.key
 metadata_expire=1d


### PR DESCRIPTION
The provided repo files should not use http to download the gpg key. Maybe it would be good to disable http on the repo server to protect the users.