### PR TITLE
EPEL/README: Remove CentOS/RHEL/OEL 6

### DIFF
--- a/epel/README.html
+++ b/epel/README.html
@@ -18,8 +18,7 @@
 
 <h3>RedHat and compatible</h3>
 <pre>dnf install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
-yum install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
-yum install https://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm</pre>
+yum install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm</pre>
 
 <p>On RHEL 7 Icinga Web 2 will also require PHP via the SCL repository system:</p>
 <pre>subscription-manager repos --enable rhel-7-server-optional-rpms
@@ -30,8 +29,7 @@ subscription-manager repos --enable rhel-server-rhscl-7-rpms</pre>
 <pre>rpm --import https://packages.icinga.com/icinga.key
 
 dnf install https://packages.icinga.com/epel/icinga-rpm-release-8-latest.noarch.rpm
-yum install https://packages.icinga.com/epel/icinga-rpm-release-7-latest.noarch.rpm
-yum install https://packages.icinga.com/epel/icinga-rpm-release-6-latest.noarch.rpm</pre>
+yum install https://packages.icinga.com/epel/icinga-rpm-release-7-latest.noarch.rpm</pre>
 
 <h2>Testing (Pre Release) Builds</h2>
 


### PR DESCRIPTION
Remove CentOS/RHEL/OEL 6 because it reached its EOL